### PR TITLE
Update Multus version | Fix ansible version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For the detail deploy instruction, check the kubespray's [readme](https://github
 |Docker         |v18.06.1-ce    |
 |CMK            |v1.3.1         |
 |NFD            |v0.3.0         |
-|Multus         |v3.1           |
+|Multus         |v3.2           |
 |Flannel        |v0.10.0        |
 |Flannel-CNI    |v0.3.0         |
 |SRIOV-CNI      |v1.0.0         |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.7.8,<=2.8
+ansible>=2.7.8,<2.8
 jinja2>=2.9.6
 netaddr
 pbr>=1.6


### PR DESCRIPTION
1. Update Multus version to v3.2 in readme file
2. Fix ansible version to fit the requirement of kubespray and Ansible vulnerability. #12